### PR TITLE
Fix username for Zack

### DIFF
--- a/docs/team/index.md
+++ b/docs/team/index.md
@@ -12,7 +12,7 @@ The maintainers maintain the project on a day-to-day basis. We previously called
 | Kriti Godey | `@kgodey:matrix.mathesar.org` | `@kgodey` | Project Lead, Product, Engineering |
 | Pavish Kumar Ramani Gopal | `@pavish:matrix.mathesar.org` | `@pavish` | Engineering |
 | Sean Colsen | `@seancolsen:matrix.mathesar.org` | `@seancolsen` | Engineering |
-| Zack Krida | `@zackkrida:matrix.mathesar.org` | `@zackkrida` | Technical Community Advocate |
+| Zack Krida | `@zack:matrix.mathesar.org` | `@zackkrida` | Technical Community Advocate |
 
 ## Staff members
 These team members also work on Mathesar, but do not maintain the open source project.


### PR DESCRIPTION
Fix Zack's matrix username on the team page.